### PR TITLE
Fix interface to nango connection delete api

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nango-ruby (1.0.3)
+    nango-ruby (1.0.4)
       faraday (>= 1)
       faraday-multipart (>= 1)
 

--- a/lib/nango/connections.rb
+++ b/lib/nango/connections.rb
@@ -12,8 +12,8 @@ module Nango
       @client.get(path: "/connection/#{id}?provider_config_key=#{provider}")
     end
 
-    def delete(id:)
-      @client.delete(path: "/connection/#{id}")
+    def delete(id:,provider:)
+      @client.delete(path: "/connection/#{id}?provider_config_key=#{provider}")
     end
   end
 end


### PR DESCRIPTION
The contract for the connections delete API is incorrect in the gem right now. As per [their doc](https://docs.nango.dev/reference/api/connection/delete) the `DELETE` connection API requires `provider_config_key` just like the `GET`. This brings it into parity. I was able to test it locally in the console and confirm I can delete a connection.