### PR TITLE
Need ability to pass in more overrides when reconnecting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nango-ruby (1.0.5)
+    nango-ruby (1.0.6)
       faraday (>= 1)
       faraday-multipart (>= 1)
 

--- a/lib/nango/connect.rb
+++ b/lib/nango/connect.rb
@@ -18,7 +18,7 @@ module Nango
           connection_id: connection_id,
           integration_id: integration_id,
           integrations_config_defaults: integrations_config_defaults
-        }
+        }.compact
       )
     end
   end

--- a/lib/nango/connect.rb
+++ b/lib/nango/connect.rb
@@ -11,12 +11,13 @@ module Nango
       )
     end
 
-    def reconnect(connection_id:, integration_id:)
+    def reconnect(connection_id:, integration_id:, integrations_config_defaults: nil)
       @client.json_post(
         path: "/connect/sessions/reconnect",
         parameters: {
           connection_id: connection_id,
-          integration_id: integration_id
+          integration_id: integration_id,
+          integrations_config_defaults: integrations_config_defaults
         }
       )
     end

--- a/lib/nango/version.rb
+++ b/lib/nango/version.rb
@@ -1,3 +1,3 @@
 module Nango
-  VERSION = "1.0.5".freeze
+  VERSION = "1.0.6".freeze
 end


### PR DESCRIPTION
I'm reusing the connection but passing in different scopes for refreshing the token and need to be able to pass it here

https://nango.dev/docs/reference/api/connect/sessions/reconnect#body-integrations-config-defaults

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reconnect now accepts optional integration configuration defaults, allowing passing default settings when re-establishing integrations.

* **Version**
  * Released version 1.0.6

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->