### PR TITLE
Add global faraday_middleware config option

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nango-ruby (1.0.7)
+    nango-ruby (1.1.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
 

--- a/README.md
+++ b/README.md
@@ -96,3 +96,11 @@ client = Nango::Client.new do |f|
   f.response :logger, Logger.new($stdout), bodies: true
 end
 ```
+
+You can also set middleware globally with `Nango.configure`, so every client gets it by default. A block or `faraday_middleware` option passed to `Nango::Client.new` takes precedence over the global config:
+
+```ruby
+Nango.configure do |config|
+  config.faraday_middleware = ->(f) { f.response :logger, Logger.new($stdout), bodies: true }
+end
+```

--- a/lib/nango.rb
+++ b/lib/nango.rb
@@ -40,7 +40,8 @@ module Nango
                   :organization_id,
                   :uri_base,
                   :request_timeout,
-                  :extra_headers
+                  :extra_headers,
+                  :faraday_middleware
 
     DEFAULT_API_VERSION = "v1".freeze
     DEFAULT_URI_BASE = "https://api.nango.dev/".freeze
@@ -56,6 +57,7 @@ module Nango
       @uri_base = DEFAULT_URI_BASE
       @request_timeout = DEFAULT_REQUEST_TIMEOUT
       @extra_headers = {}
+      @faraday_middleware = nil
     end
   end
 

--- a/lib/nango/client.rb
+++ b/lib/nango/client.rb
@@ -12,8 +12,9 @@ module Nango
       uri_base
       request_timeout
       extra_headers
+      faraday_middleware
     ].freeze
-    attr_reader *CONFIG_KEYS, :faraday_middleware
+    attr_reader *CONFIG_KEYS
 
     def initialize(config = {}, &faraday_middleware)
       CONFIG_KEYS.each do |key|
@@ -24,7 +25,7 @@ module Nango
           config[key].nil? ? Nango.configuration.send(key) : config[key]
         )
       end
-      @faraday_middleware = faraday_middleware
+      @faraday_middleware = faraday_middleware if faraday_middleware
     end
 
     def providers

--- a/lib/nango/version.rb
+++ b/lib/nango/version.rb
@@ -1,3 +1,3 @@
 module Nango
-  VERSION = "1.0.7".freeze
+  VERSION = "1.1.0".freeze
 end

--- a/spec/nango/client_spec.rb
+++ b/spec/nango/client_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe Nango::Client do
+  describe "faraday_middleware" do
+    it "defaults to nil" do
+      expect(described_class.new.faraday_middleware).to be_nil
+    end
+
+    it "falls back to the global configuration" do
+      middleware = ->(f) { f }
+      Nango.configure { |config| config.faraday_middleware = middleware }
+
+      expect(described_class.new.faraday_middleware).to eq(middleware)
+    end
+
+    it "can be set per client" do
+      middleware = ->(f) { f }
+
+      client = described_class.new(faraday_middleware: middleware)
+
+      expect(client.faraday_middleware).to eq(middleware)
+    end
+
+    it "prefers the block over the global configuration" do
+      Nango.configure { |config| config.faraday_middleware = ->(f) { f } }
+      block = ->(f) { f }
+
+      client = described_class.new(&block)
+
+      expect(client.faraday_middleware).to eq(block)
+    end
+
+    it "applies the middleware to the Faraday connection" do
+      received = nil
+      Nango.configure do |config|
+        config.access_token = "token"
+        config.faraday_middleware = ->(f) { received = f }
+      end
+      stub_request(:get, "https://api.nango.dev/providers").to_return(
+        status: 200,
+        body: '{"providers": []}',
+        headers: { "Content-Type" => "application/json" }
+      )
+
+      described_class.new.get(path: "/providers")
+
+      expect(received).to be_a(Faraday::Connection)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+require "nango"
+require "webmock/rspec"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+
+  config.around do |example|
+    original_configuration = Nango.instance_variable_get(:@configuration)
+    Nango.configuration = Nango::Configuration.new
+    example.run
+  ensure
+    Nango.instance_variable_set(:@configuration, original_configuration)
+  end
+end


### PR DESCRIPTION
Adds a `faraday_middleware` accessor to `Nango::Configuration` so middleware can be set once via `Nango.configure` and applied to every client, e.g. `config.faraday_middleware = ->(conn) { conn.use MyMiddleware }`. `faraday_middleware` joins `CONFIG_KEYS` in `Nango::Client`, so precedence is: per-instance block > `Client.new(faraday_middleware: ...)` option > global config > nil. Adds the gem's first RSpec suite (spec_helper, .rspec, client specs) covering the default, the config fallback, block precedence, and that the middleware actually runs against the Faraday connection. Bumps the version to 1.1.0 and documents the global form in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring middleware globally, with per-client overrides when needed.
  * Updated the package version to 1.1.0.

* **Documentation**
  * Expanded the README with clearer setup guidance for middleware configuration and override behavior.

* **Bug Fixes**
  * Improved test setup so the suite consistently loads the shared test helper and starts from a clean configuration state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->